### PR TITLE
Fix Docker CMD path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY . .
 EXPOSE 8080
 
 # Use o shell para passar a variável de ambiente PORT ao Streamlit
-CMD streamlit run app/main.py \
+CMD streamlit run src/app.py \
     --server.port=${PORT:-8080} \
     --server.address=0.0.0.0 \
     --server.headless=true \


### PR DESCRIPTION
## Summary
- correct path of Streamlit entry point in Dockerfile

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68759b2920208320bfd81d0f702dbc62